### PR TITLE
Fix README and prometheus_metrics_parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ pip install prometheus-client
 ## Usage 
 ## Configuring and running a gRPC server
 
-Here's a simple example of how to use grpc_connection_forwarder with a gRPC server and prometeus-client:
+Here's a simple example of how to use grpc_load_balancer with a gRPC server and prometeus-client:
 
 # Import the required modules:
 ```python 
 import grpc
-from grpc_connection_forwarder import GrpcConnnectionForwarder
+from grpc_load_balancer import GrpcConnnectionForwarder
 from prometheus_client import start_http_server, Gauge
 ```
 
@@ -43,8 +43,7 @@ from prometheus_client import start_http_server, Gauge
 # Initialize your gRPC server(s)
 ```python
     grpc_server = create_example_grpc_server() # implement this function yourself
-    connection_counter = Gauge(
-        f'connections_num', 'Number of connections forwarded')
+    connection_counter = Gauge('connections_num', 'Number of connections forwarded')
     forwarder = GrpcConnnectionForwarder(
         grpc_server, callback=lambda value: connection_counter.set(value)
     )
@@ -62,7 +61,7 @@ from prometheus_client import start_http_server, Gauge
 # Import the required modules:    
 ```python
 import grpc
-from grpc_connection_forwarder import EnvConfigLoader, MetricsBasedServerFinder
+from grpc_load_balancer import EnvConfigLoader, MetricsBasedServerFinder
 ```
 
 
@@ -96,6 +95,7 @@ If you have any problems with `grpc_load_balancer`, please open an issue on GitH
 Also, you can check [tests/test_grpc_load_balancer.py](tests/test_grpc_load_balancer.py) for more information.
 
 ## Contributing
+
 We welcome contributions to `grpc_load_balancer`. If you find a bug or want to propose a new feature, please open a GitHub issue or submit a pull request.
 
 ## License

--- a/grpc_load_balancer/metrics_based_server_finder.py
+++ b/grpc_load_balancer/metrics_based_server_finder.py
@@ -1,4 +1,6 @@
+import re
 import requests
+
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 
@@ -46,7 +48,7 @@ class MetricsBasedServerFinder:
             return None
 
     def _parse_prometheus_metrics(self, response_text: str) -> Optional[float]:
-        for line in response_text.split("\n"):
-            if line.startswith(self.metrics_name):
-                return float(line[len(self.metrics_name):].strip().split(" ")[0])
-        return None
+        pattern = rf"{self.metrics_name}(?:\s*{{[^}}]*}})?\s+(\d+\.\d+)"
+        match = re.search(pattern, response_text)
+
+        return float(match.group(1)) if match else None


### PR DESCRIPTION
This PR replaces all the mentions of depricated `grpc_connection_forwarder` to `grpc_load_balancer` in README. 
It also adjusts logic for `prometheus_metrics_parsing` function to account for prometheus labels and always take last numeric value from the line. Line iterator has been replaced with regular expression, because on my tests it works 1.6 times faster than line iterator (0.52375s vs 0.32459s on 100000 iterations). This also allows for potentially different regular expressions to be passed during initialization to make the module more customizable in the future.